### PR TITLE
Checkout master on push

### DIFF
--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -42,12 +42,17 @@ jobs:
         with:
           ref: 'refs/heads/master'
 
+      - name: Get HEAD ref
+        id: head-ref
+        run: echo "::set-output name=ref::$(git rev-parse HEAD)"
+
       - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
 
-      - run: npm ci
-
       - name: Publish
-        run: node ./scripts/pushToServer.js
+        if: ${{ github.sha == steps.head-ref.outputs.ref }}
+        run: |
+          npm ci
+          node ./scripts/pushToServer.js

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -39,6 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: 'refs/heads/master'
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
This is a band-aid fix. 
We should re-think the automation of pushing ddocs to the staging server to avoid complications around re-running old jobs. 

#20 