### PR TITLE
Uplift GitHub workflows to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -9,7 +9,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   push:
     needs: test
     name: Push to builds server
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: ${{ github.ref == 'refs/heads/master' }}
 
     steps:


### PR DESCRIPTION
Updates the GitHub workflows so that they run on the latest `ubuntu-22.04` image.

https://github.com/medic/cht-core/issues/7741